### PR TITLE
Add helper to check pack operating state

### DIFF
--- a/src/bms/battery i3/pack.cpp
+++ b/src/bms/battery i3/pack.cpp
@@ -498,6 +498,8 @@ bool BatteryPack::get_any_module_balancing()
 
 BatteryPack::STATE_PACK BatteryPack::getState() { return state; }
 
+bool BatteryPack::get_state_operating() { return state == OPERATING; }
+
 BatteryPack::DTC_PACK BatteryPack::getDTC() { return dtc; }
 
 bool BatteryPack::get_balancing_active() { return balanceActive; }

--- a/src/bms/battery i3/pack.h
+++ b/src/bms/battery i3/pack.h
@@ -45,6 +45,7 @@ public:
 
     // Our state
     STATE_PACK getState();
+    bool get_state_operating();
     DTC_PACK getDTC();
 
     // Helper functions


### PR DESCRIPTION
## Summary
- add `get_state_operating` method to `BatteryPack`

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e94b7bce0832babbc52f309fd3e07