### PR TITLE
Fix pack comments and clean headers

### DIFF
--- a/src/bms/battery i3/module.cpp
+++ b/src/bms/battery i3/module.cpp
@@ -327,7 +327,7 @@ float BatteryModule::get_lowest_temperature()
 // Return the temperature of the hottest sensor in the module
 float BatteryModule::get_highest_temperature()
 {
-    float highestTemperature = -50;
+    float highestTemperature = -50.0;
     for (int t = 0; t < numTemperatureSensors; t++)
     {
         if (cellTemperature[t] > highestTemperature)

--- a/src/bms/battery i3/pack.cpp
+++ b/src/bms/battery i3/pack.cpp
@@ -159,7 +159,7 @@ void BatteryPack::request_data()
         }
     }
 
-    // Byte 5: is alsways 0x00
+    // Byte 5: is always 0x00
     pollModuleFrame.data[5] = 0x00;
 
     // Byte 6: has the frame counter in the higher nibble. One bit is set at the end of startup.

--- a/src/bms/battery i3/pack.h
+++ b/src/bms/battery i3/pack.h
@@ -78,15 +78,13 @@ private:
     bool balanceActive;
 
     // private variables for polling
-    uint8_t pollMessageId;
-    bool initialised;
     CRC8 crc8;
     bool inStartup;
     uint8_t modulePollingCycle;
     uint8_t moduleToPoll;
     CANMessage pollModuleFrame;
 
-    // sate and dtc
+    // state and dtc
     STATE_PACK state;
     DTC_PACK dtc;
 


### PR DESCRIPTION
## Summary
- fix highestTemperature initialization in `BatteryModule`
- remove unused variables from `BatteryPack`
- correct typos in comments

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9412b2bc832b88304b1f4508284a