### PR TITLE
Fix DTC updates in BatteryModule

### DIFF
--- a/src/bms/battery i3/module.cpp
+++ b/src/bms/battery i3/module.cpp
@@ -216,12 +216,12 @@ void BatteryModule::process_message(CANMessage &msg)
         if (cmuError)
         {
             state = FAULT;
-            dtc |= DTC_CMU_INTERNAL_ERROR;
+            dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_INTERNAL_ERROR);
         }
         if (temperatureInternal > CMU_MAX_INTERNAL_WARNING_TEMPERATURE)
         {
             state = FAULT;
-            dtc |= DTC_CMU_TEMPERATURE_TOO_HIGH;
+            dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_TEMPERATURE_TOO_HIGH);
         }
         if (plausibilityCheck() == false)
         {
@@ -235,12 +235,12 @@ void BatteryModule::process_message(CANMessage &msg)
         if (cmuError)
         {
             state = FAULT;
-            dtc |= DTC_CMU_INTERNAL_ERROR;
+            dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_INTERNAL_ERROR);
         }
         if (temperatureInternal > CMU_MAX_INTERNAL_WARNING_TEMPERATURE)
         {
             state = FAULT;
-            dtc |= DTC_CMU_TEMPERATURE_TOO_HIGH;
+            dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_TEMPERATURE_TOO_HIGH);
         }
         if (plausibilityCheck() == false)
         {
@@ -349,7 +349,7 @@ void BatteryModule::check_alive()
         if ((millis() - lastUpdate) > PACK_ALIVE_TIMEOUT)
         {
             state = FAULT;
-            dtc |= DTC_CMU_TIMED_OUT;
+            dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_TIMED_OUT);
             // Serial.println(String(millis()) + ": Timed out");
         }
         break;
@@ -364,12 +364,12 @@ bool BatteryModule::plausibilityCheck()
     if ((get_lowest_cell_voltage() < CMU_MIN_PLAUSIBLE_VOLTAGE) || (get_highest_cell_voltage() > CMU_MAX_PLAUSIBLE_VOLTAGE))
     {
         plausible = false;
-        dtc |= DTC_CMU_SINGLE_VOLTAGE_IMPLAUSIBLE;
+        dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_SINGLE_VOLTAGE_IMPLAUSIBLE);
     }
     if ((get_lowest_temperature() < CMU_MIN_PLAUSIBLE_TEMPERATURE) || (get_highest_temperature() > CMU_MAX_PLAUSIBLE_TEMPERATURE))
     {
         plausible = false;
-        dtc |= DTC_CMU_TEMPERATURE_IMPLAUSIBLE;
+        dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_TEMPERATURE_IMPLAUSIBLE);
     }
 
     float totalVoltage = 0.0000f;
@@ -381,7 +381,7 @@ bool BatteryModule::plausibilityCheck()
     if (((totalVoltage - CMU_MAX_DELTA_MODULE_CELL_VOLTAGE) > moduleVoltage) || ((totalVoltage + CMU_MAX_DELTA_MODULE_CELL_VOLTAGE) < moduleVoltage))
     {
         plausible = false;
-        dtc |= DTC_CMU_MODULE_VOLTAGE_IMPLAUSIBLE;
+        dtc = static_cast<DTC_CMU>(dtc | DTC_CMU_MODULE_VOLTAGE_IMPLAUSIBLE);
     }
     return plausible;
 }


### PR DESCRIPTION
## Summary
- avoid implicit enum conversions when updating `dtc` in `BatteryModule`

## Testing
- `pio run -t check` *(fails: `bash: pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c54335eb8832b90e86f7f74fe2cb4