### PR TITLE
Implement status print helpers

### DIFF
--- a/src/serial_console.h
+++ b/src/serial_console.h
@@ -10,5 +10,6 @@ void serial_console();
 void print_console_help();
 void print_pack_status();
 void print_module_status(int index);
+void print_contactor_status();
 
 #endif // SERIAL_CONSOLE_H


### PR DESCRIPTION
## Summary
- add helper to print contactor state and module status
- call these helpers from the serial console

## Testing
- `pio run -e teensy41 -t clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eab0829dc832bbb82adc6d3e70bee