### PR TITLE
Add vehicle state reception

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -14,6 +14,7 @@ BMS::BMS(BatteryPack &_batteryPack, Shunt_ISA_iPace &_shunt, Contactormanager &_
     state = INIT;
     dtc = DTC_BMS_NONE;
     moduleToBeMonitored = 0;
+    vehicle_state = STATE_SLEEP;
 }
 
 void BMS::initialize()
@@ -118,6 +119,10 @@ void BMS::read_message()
 
     if (ACAN_T4::BMS_CAN.receive(msg))
     {
+        if (msg.id == VCU_STATUS_MSG_ID && msg.len >= 1)
+        {
+            vehicle_state = static_cast<VehicleState>(msg.data[0]);
+        }
         //Incoming from Main
         //  Energy state - struct
         //  Close contactor manually/ open boolean
@@ -340,6 +345,11 @@ void BMS::send_message(CANMessage *frame)
         dtc |= DTC_BMS_CAN_SEND_ERROR;
         // Serial.println("Send nok");
     }
+}
+
+BMS::VehicleState BMS::get_vehicle_state()
+{
+    return vehicle_state;
 }
 
 

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -31,6 +31,20 @@ public:
         DTC_BMS_PACK_FAULT = 1 << 2,
     } DTC_BMS;
 
+    enum VehicleState
+    {
+        STATE_SLEEP = 0,
+        STATE_STANDBY,
+        STATE_READY,
+        STATE_CONDITIONING,
+        STATE_DRIVE,
+        STATE_CHARGE,
+        STATE_ERROR,
+        STATE_LIMP_HOME
+    };
+
+    static const uint16_t VCU_STATUS_MSG_ID = 0x500; // CAN message containing vehicle state
+
     BMS(BatteryPack &_batteryPack, Shunt_ISA_iPace &_shunt, Contactormanager &_contactorManager); // Constructor taking a reference to BatteryPack
 
     // Runnables
@@ -44,6 +58,8 @@ public:
 
     void Monitor100Ms();
     // void Monitor1000Ms();
+
+    VehicleState get_vehicle_state();
 
 private:
     BatteryPack &batteryPack; // Reference to the BatteryPack
@@ -92,6 +108,9 @@ private:
     void send_message(CANMessage *frame); // Send out CAN message
 
     byte moduleToBeMonitored;
+
+    // Current vehicle state received from the VCU
+    VehicleState vehicle_state;
 
     // State and DTC
     STATE_BMS state;


### PR DESCRIPTION
## Summary
- add VehicleState enum and CAN ID constant
- store latest vehicle state in `BMS`
- parse vehicle state CAN message
- expose getter for vehicle state

## Testing
- `pio run -e teensy41` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712957e138832ba3764b7b32f9c37c