### PR TITLE
Add BMS state stubs

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -234,3 +234,26 @@ void BMS::send_message(CANMessage *frame)
     }
 }
 
+// --- Core Algorithm Stubs -------------------------------------------------
+
+void BMS::calculate_soc_ocv_lut() {}
+void BMS::calculate_soc_coulomb_counting() {}
+void BMS::calculate_soc_correction() {}
+void BMS::calculate_soh() {}
+
+void BMS::lookup_current_limits() {}
+void BMS::lookup_internal_resistance_table() {}
+void BMS::estimate_internal_resistance_online() {}
+void BMS::select_internal_resistance_used() {}
+
+void BMS::calculate_voltage_derate() {}
+void BMS::calculate_rms_ema() {}
+void BMS::calculate_dynamic_voltage_limit() {}
+
+void BMS::select_current_limit() {}
+
+void BMS::calculate_limp_home_limit() {}
+void BMS::select_limp_home() {}
+
+void BMS::rate_limit_current() {}
+

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -66,10 +66,50 @@ private:
     float internal_resistance[CELLS_PER_MODULE * MODULES_PER_PACK];
     float open_circuite_voltage[CELLS_PER_MODULE * MODULES_PER_PACK];
 
+    // --- Inputs / Raw Data ---
+    float cell_voltage[CELLS_PER_MODULE * MODULES_PER_PACK];
+    float cell_temp[CELLS_PER_MODULE * MODULES_PER_PACK];
+    float pack_current;
+    float dt;
+    bool invalid_data;
+
     float power; // in Ws
 
     // SOC
-    float soc_coulomb_counting;
+    float soc_ocv_lut;       // SOC from OCV-Temp LUT
+    float soc_coulomb_counting; // SOC from coulomb counting
+    float soc;               // Corrected SOC
+
+    // --- SOH (Monitoring Only) ---
+    float measured_capacity_Ah; // Integrated capacity over a full cycle
+
+    // --- Current Limits (Temperature) ---
+    float current_limit_peak;        // Peak allowed current (A)
+    float current_limit_rms;         // RMS allowed current (A)
+    float current_limit_rms_derated; // Derated RMS current limit
+
+    // --- Internal Resistance (IR) ---
+    float internal_resistance_table;                                // IR from LUT
+    float internal_resistance_estimated;                            // IR from online estimation
+    float internal_resistance_estimated_cells[CELLS_PER_MODULE * MODULES_PER_PACK]; // IR from online estimation, per cell
+    float internal_resistance_used;                                 // Max(IR_table, IR_estimated)
+    float internal_resistance_used_min;                             // Smallest IR (best cell)
+    float internal_resistance_used_max;                             // Largest IR (worst cell)
+
+    // --- Voltage Derating ---
+    // Placeholder for derating factor/state
+
+    // --- Dynamic Voltage Limit ---
+    float current_limit_voltage_dynamic;
+
+    // --- RMS Calculation ---
+    // Placeholder for EMA and soft clamp state variables
+
+    // --- Final Allowed Current ---
+    float current_limit_allowed;     // Output of min-selector
+    float current_limit_limp_home;   // Limp home current limit
+    float current_limit_selected;    // After limp home logic
+    float current_limit_final;       // After rate limiter
 
     // Non-Volatile Variable!!
     float watt_seconds;
@@ -77,6 +117,28 @@ private:
     float total_capacity = BMS_TOTAL_CAPACITY;
 
     void send_battery_status_message();
+
+    // --- Core Functions ---
+    void calculate_soc_ocv_lut();
+    void calculate_soc_coulomb_counting();
+    void calculate_soc_correction();
+    void calculate_soh();
+
+    void lookup_current_limits();
+    void lookup_internal_resistance_table();
+    void estimate_internal_resistance_online();
+    void select_internal_resistance_used();
+
+    void calculate_voltage_derate();
+    void calculate_rms_ema();
+    void calculate_dynamic_voltage_limit();
+
+    void select_current_limit();
+
+    void calculate_limp_home_limit();
+    void select_limp_home();
+
+    void rate_limit_current();
 
     //         // State maschine updating
     //         void update_state_machine();


### PR DESCRIPTION
## Summary
- extend `BMS` state with stub variables for future algorithms
- declare placeholder methods for SOC, SOH and current limit calculations
- provide empty implementations of new methods

## Testing
- `g++ -std=c++17 -fsyntax-only src/bms/battery_manager.cpp` *(fails: ACAN_T4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687394b3f084832bbf607fdfff36cd8e