### PR TITLE
Add SOC update helpers

### DIFF
--- a/src/bms/battery i3/pack.cpp
+++ b/src/bms/battery i3/pack.cpp
@@ -334,6 +334,25 @@ float BatteryPack::get_highest_temperature()
     return highestModuleTemperature;
 }
 
+// return the average temperature of all modules in the pack
+float BatteryPack::get_average_temperature()
+{
+    float sumTemp = 0.0f;
+    int numTemp = 0;
+
+    for (int m = 0; m < numModules; m++)
+    {
+        if (modules[m].getState() != BatteryModule::OPERATING)
+        {
+            continue;
+        }
+        sumTemp += modules[m].get_average_temperature();
+        numTemp++;
+    }
+
+    return (numTemp > 0) ? sumTemp / numTemp : 0.0f;
+}
+
 const char *BatteryPack::getStateString()
 {
     switch (state)

--- a/src/bms/battery i3/pack.h
+++ b/src/bms/battery i3/pack.h
@@ -69,6 +69,7 @@ public:
     //   Temperature
     float get_lowest_temperature();
     float get_highest_temperature();
+    float get_average_temperature();
     bool get_cell_temperature(byte cell, float &temperature);
 
 private:

--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -5,6 +5,7 @@
 #include "bms/current.h"
 #include "bms/contactor_manager.h"
 #include "utils/can_packer.h"
+#include "utils/soc_lookup.h"
 #include <math.h>
 
 // #define DEBUG
@@ -236,9 +237,25 @@ void BMS::send_message(CANMessage *frame)
 
 // --- Core Algorithm Stubs -------------------------------------------------
 
-void BMS::calculate_soc_ocv_lut() {}
-void BMS::calculate_soc_coulomb_counting() {}
-void BMS::calculate_soc_correction() {}
+void BMS::update_soc_ocv_lut() {
+    if (fabs(pack_current) <= BMS_OCV_CURRENT_THRESHOLD) {
+        // Use lowest cell voltage across the pack as OCV reference
+        const float ocv = batteryPack.get_lowest_cell_voltage();
+
+        // Average pack temperature handled by BatteryPack
+        const float avgTemp = batteryPack.get_average_temperature();
+
+        soc_ocv_lut = SOC_FROM_OCV_TEMP(avgTemp, ocv);
+    }
+}
+
+void BMS::update_soc_coulomb_counting() {
+    soc_coulomb_counting = 0.0f;
+}
+
+void BMS::correct_soc() {
+    soc = soc_ocv_lut;
+}
 void BMS::calculate_soh() {}
 
 void BMS::lookup_current_limits() {}

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -119,9 +119,9 @@ private:
     void send_battery_status_message();
 
     // --- Core Functions ---
-    void calculate_soc_ocv_lut();
-    void calculate_soc_coulomb_counting();
-    void calculate_soc_correction();
+    void update_soc_ocv_lut();
+    void update_soc_coulomb_counting();
+    void correct_soc();
     void calculate_soh();
 
     void lookup_current_limits();

--- a/src/settings.h
+++ b/src/settings.h
@@ -62,6 +62,9 @@
 
 #define BMS_MAX_DISCHARGE_PEAK_CURRENT 406 * 0.9 //Safetyfactor
 
+// Maximum absolute pack current (A) for valid OCV-based SOC estimation
+#define BMS_OCV_CURRENT_THRESHOLD 0.5f
+
 // //Discharge Limits
 // const int16_t temperatures[] PROGMEM = {60, 50, 40, 35, 30, 25, 20, 15, 10, 5, 0, -5, -10, -15, -20, -25, -30, -40};
 // const int16_t continuous_discharge_CurrentLimits[] PROGMEM = {223, 223, 223, 210, 196, 180, 166, 153, 136, 124, 108, 93, 77, 74, 62, 57, 46, 33};


### PR DESCRIPTION
## Summary
- implement SOC estimation when current is below threshold
- return zero in placeholder for coulomb counting
- add correction step to pass through OCV LUT value
- define `BMS_OCV_CURRENT_THRESHOLD` setting

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687396965dcc832ba681e05a5c069056