### PR TITLE
Implement cold temperature limits

### DIFF
--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -84,9 +84,12 @@ private:
     float measured_capacity_Ah; // Integrated capacity over a full cycle
 
     // --- Current Limits (Temperature) ---
-    float current_limit_peak;        // Peak allowed current (A)
-    float current_limit_rms;         // RMS allowed current (A)
-    float current_limit_rms_derated; // Derated RMS current limit
+    float current_limit_peak;        // Peak allowed current (A) - discharge direction
+    float current_limit_rms;         // RMS allowed current (A)  - discharge direction
+    float current_limit_peak_charge; // Peak charge current (A)
+    float current_limit_rms_charge;  // Continuous charge current (A)
+    float current_limit_rms_derated_discharge; // Derated RMS current limit for discharge
+    float current_limit_rms_derated_charge;    // Derated RMS current limit for charge
 
     // --- Internal Resistance (IR) ---
     float internal_resistance_table;                                // IR from LUT

--- a/src/settings.h
+++ b/src/settings.h
@@ -62,6 +62,12 @@
 
 #define BMS_MAX_DISCHARGE_PEAK_CURRENT 406 * 0.9 //Safetyfactor
 
+// Voltage thresholds for current derating
+#define V_MIN_DERATE 3.3f
+#define V_MIN_CUTOFF 3.0f
+#define V_MAX_DERATE 4.1f
+#define V_MAX_CUTOFF 4.2f
+
 // //Discharge Limits
 // const int16_t temperatures[] PROGMEM = {60, 50, 40, 35, 30, 25, 20, 15, 10, 5, 0, -5, -10, -15, -20, -25, -30, -40};
 // const int16_t continuous_discharge_CurrentLimits[] PROGMEM = {223, 223, 223, 210, 196, 180, 166, 153, 136, 124, 108, 93, 77, 74, 62, 57, 46, 33};


### PR DESCRIPTION
## Summary
- use the coldest cell temperature for current limit lookup
- derive charge and discharge continuous and peak limits
- derate charge and discharge current based on cell voltages

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687397b54c90832ba468cdfa804a0b89