### PR TITLE
Add online internal resistance estimation

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -243,7 +243,60 @@ void BMS::calculate_soh() {}
 
 void BMS::lookup_current_limits() {}
 void BMS::lookup_internal_resistance_table() {}
-void BMS::estimate_internal_resistance_online() {}
+void BMS::estimate_internal_resistance_online() {
+    const float current_threshold = IR_ESTIMATION_CURRENT_STEP_THRESHOLD;
+    const float alpha = IR_ESTIMATION_ALPHA;
+
+    static bool first_run = true;
+    static float last_pack_current = 0.0f;
+    static float last_cell_voltage[CELLS_PER_MODULE * MODULES_PER_PACK] = {0};
+
+    // Gather current and voltages
+    pack_current = shunt.getCurrent();
+
+    for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i) {
+        float v;
+        if (batteryPack.get_cell_voltage(i, v)) {
+            cell_voltage[i] = v;
+        } else {
+            cell_voltage[i] = 0.0f;
+        }
+    }
+
+    if (first_run) {
+        last_pack_current = pack_current;
+        for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i) {
+            last_cell_voltage[i] = cell_voltage[i];
+            internal_resistance_estimated_cells[i] = 0.0f;
+        }
+        first_run = false;
+        return;
+    }
+
+    float deltaI = pack_current - last_pack_current;
+
+    if (fabs(deltaI) > current_threshold) {
+        for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i) {
+            float deltaV = cell_voltage[i] - last_cell_voltage[i];
+            float ir_sample = (deltaI != 0.0f) ? deltaV / deltaI : 0.0f;
+            internal_resistance_estimated_cells[i] =
+                alpha * ir_sample + (1.0f - alpha) * internal_resistance_estimated_cells[i];
+        }
+    }
+
+    last_pack_current = pack_current;
+    for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i) {
+        last_cell_voltage[i] = cell_voltage[i];
+    }
+
+    // Compute average pack internal resistance from estimated cell values
+    float sum_ir = 0.0f;
+    for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i) {
+        sum_ir += internal_resistance_estimated_cells[i];
+    }
+    internal_resistance_estimated =
+        sum_ir / static_cast<float>(CELLS_PER_MODULE * MODULES_PER_PACK);
+}
 void BMS::select_internal_resistance_used() {}
 
 void BMS::calculate_voltage_derate() {}

--- a/src/settings.h
+++ b/src/settings.h
@@ -62,6 +62,10 @@
 
 #define BMS_MAX_DISCHARGE_PEAK_CURRENT 406 * 0.9 //Safetyfactor
 
+// Internal resistance online estimation parameters
+#define IR_ESTIMATION_CURRENT_STEP_THRESHOLD 1.0f
+#define IR_ESTIMATION_ALPHA 0.1f
+
 // //Discharge Limits
 // const int16_t temperatures[] PROGMEM = {60, 50, 40, 35, 30, 25, 20, 15, 10, 5, 0, -5, -10, -15, -20, -25, -30, -40};
 // const int16_t continuous_discharge_CurrentLimits[] PROGMEM = {223, 223, 223, 210, 196, 180, 166, 153, 136, 124, 108, 93, 77, 74, 62, 57, 46, 33};


### PR DESCRIPTION
## Summary
- add configuration constants for internal resistance estimation
- implement `BMS::estimate_internal_resistance_online` using pack current and cell voltages

## Testing
- `pio` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a5257638832bad4b46c5fddcc72f