### PR TITLE
Implement new BMS CAN messages with CRC

### DIFF
--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -43,8 +43,7 @@ public:
         STATE_LIMP_HOME
     };
 
-    static const uint16_t VCU_STATUS_MSG_ID = 0x437; // CAN message containing vehicle state
-
+    
     BMS(BatteryPack &_batteryPack, Shunt_ISA_iPace &_shunt, Contactormanager &_contactorManager); // Constructor taking a reference to BatteryPack
 
     // Runnables
@@ -150,6 +149,16 @@ private:
     void send_message(CANMessage *frame); // Send out CAN message
 
     byte moduleToBeMonitored;
+
+    uint8_t msg1_counter;
+    uint8_t msg2_counter;
+    uint8_t msg3_counter;
+    uint8_t msg4_counter;
+    uint8_t msg5_counter;
+
+    uint8_t vcu_counter;
+    unsigned long last_vcu_msg;
+    bool vcu_timeout;
 
     // Current vehicle state received from the VCU
     VehicleState vehicle_state;

--- a/src/settings.h
+++ b/src/settings.h
@@ -54,6 +54,13 @@
 //BMS software module settings
 //---------------------------------------------------------------------------------------------------------------------------------------------
 #define BMS_CAN can3
+#define BMS_VCU_MSG_ID 0x437
+#define BMS_MSG_VOLTAGE 0x41A
+#define BMS_MSG_CELL_TEMP 0x41B
+#define BMS_MSG_LIMITS 0x41C
+#define BMS_MSG_SOC 0x41D
+#define BMS_MSG_HMI 0x41E
+#define BMS_VCU_TIMEOUT 100
 
 #define BMS_TOTAL_CAPACITY 345 * 3600 * CELLS_PER_MODULE; //Num modules missing 345Wh 3600 s/H 12 Cells. Unit: Ws
 

--- a/src/utils/can_crc.h
+++ b/src/utils/can_crc.h
@@ -1,0 +1,34 @@
+#ifndef CAN_CRC_H
+#define CAN_CRC_H
+
+#include <stdint.h>
+
+static inline uint32_t crc32_word(uint32_t Crc, uint32_t Data)
+{
+    Crc ^= Data;
+    for (int i = 0; i < 32; i++) {
+        if (Crc & 0x80000000U)
+            Crc = (Crc << 1) ^ 0x04C11DB7U;
+        else
+            Crc <<= 1;
+    }
+    return Crc;
+}
+
+static inline uint32_t crc32(const uint32_t *data, uint32_t len, uint32_t crc)
+{
+    for (uint32_t i = 0; i < len; i++)
+        crc = crc32_word(crc, data[i]);
+    return crc;
+}
+
+static inline uint8_t can_crc8(const uint8_t *bytes)
+{
+    uint32_t buf[2];
+    buf[0] = ((uint32_t)bytes[3] << 24) | ((uint32_t)bytes[2] << 16) | ((uint32_t)bytes[1] << 8) | bytes[0];
+    buf[1] = ((uint32_t)bytes[7] << 24) | ((uint32_t)bytes[6] << 16) | ((uint32_t)bytes[5] << 8) | bytes[4];
+    uint32_t crc = crc32(buf, 2, 0xFFFFFFFFU);
+    return (uint8_t)(crc & 0xFFU);
+}
+
+#endif // CAN_CRC_H


### PR DESCRIPTION
## Summary
- add helper for CRC32 based CAN CRC
- define IDs and timeout constants for BMS CAN messaging
- store counters and VCU timeout info in the BMS manager
- parse new VCU->BMS control message with CRC checking
- send new BMS status messages according to updated spec

## Testing
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68756b7d05a0832b9918308194f0f3f8