### PR TITLE
Fix Map3D constructor initialization

### DIFF
--- a/src/utils/Map2D3D.h
+++ b/src/utils/Map2D3D.h
@@ -171,9 +171,12 @@ public:
         {
             x2s[i] = 0;
         }
-        for (int i = 0; i < R * C; i++)
+        for (int i = 0; i < R; i++)
         {
-            ys[i] = 0;
+            for (int j = 0; j < C; j++)
+            {
+                ys[i][j] = 0;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- clear multi-dimensional array correctly in `Map3D` constructor

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687572589988832b86dd852820714623