### PR TITLE
Send full contactor state

### DIFF
--- a/documentation/CAN_Message_Packing.md
+++ b/documentation/CAN_Message_Packing.md
@@ -31,7 +31,7 @@ The following tables describe the structure of all CAN messages exchanged betwee
 |-----|--------|------|---------------|-------|-------|
 | 0-1 | Max Discharge Current | `uint16` | A × 10 | 0–65535 | 0–6553.5 A |
 | 2-3 | Max Charge Current | `uint16` | A × 10 | 0–65535 | 0–6553.5 A |
-| 4 | Contactor Status | `uint8` | 0=open, 1=closed | 0–1 | boolean as `uint8` |
+| 4 | Contactor State | `uint8` | enum | 0–7 | 0=INIT,1=OPEN,2=CLOSING_PRE,3=CLOSING_POS,4=CLOSED,5=OPENING_POS,6=OPENING_PRE,7=FAULT |
 | 5 | Fault Code | `uint8` |  | 0–255 | enum |
 | 6 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
 | 7 | CRC8 | `uint8` |  |  |  |

--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -397,7 +397,7 @@ void BMS::send_battery_status_message()
     msg.data[1] = maxD >> 8;
     msg.data[2] = maxC & 0xFF;
     msg.data[3] = maxC >> 8;
-    msg.data[4] = contactorManager.getState() == Contactormanager::CLOSED ? 1 : 0;
+    msg.data[4] = static_cast<uint8_t>(contactorManager.getState());
     msg.data[5] = static_cast<uint8_t>(dtc);
     msg.data[6] = msg3_counter & 0x0F;
     msg.data[7] = 0;


### PR DESCRIPTION
## Summary
- send contactor state enum instead of boolean
- document the contactor state enum in CAN specs

## Testing
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6875727156ec832bae94b47be59755ce