### PR TITLE
Fix enum bitmask operations

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -72,7 +72,7 @@ void BMS::initialize()
     {
         Serial.print("Error BMS CAN: 0x");
         Serial.println(errorCode, HEX);
-        dtc |= DTC_BMS_CAN_INIT_ERROR;
+        dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_CAN_INIT_ERROR);
     }
 
     contactorManager.close();
@@ -200,7 +200,7 @@ void BMS::send_message(CANMessage *frame)
     }
     else
     {
-        dtc |= DTC_BMS_CAN_SEND_ERROR;
+        dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_CAN_SEND_ERROR);
         // Serial.println("Send nok");
     }
 }

--- a/src/bms/current.cpp
+++ b/src/bms/current.cpp
@@ -58,7 +58,7 @@ void Shunt_ISA_iPace::initialise()
     {
         Serial.print("Error Shunt CAN: 0x");
         Serial.println(errorCode, HEX);
-        _dtc |= DTC_ISA_CAN_INIT_ERROR;
+        _dtc = static_cast<DTC_ISA>(_dtc | DTC_ISA_CAN_INIT_ERROR);
     }
 
 


### PR DESCRIPTION
## Summary
- fix compilation error for bitmasked enum values

## Testing
- `g++ /tmp/test.cpp -std=c++11 -Wall`

------
https://chatgpt.com/codex/tasks/task_e_687575125154832ba6a98bb07350a49c