### PR TITLE
Activate BMS state machine

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -78,21 +78,21 @@ void BMS::initialize()
     contactorManager.close();
 }
 
-void BMS::Task2Ms() { read_message(); } // Read Can messages ?
+void BMS::Task2Ms() { read_message(); }
+
 void BMS::Task10Ms()
 {
-
-
+    update_state_machine();
 }
 
 void BMS::Task100Ms()
 {
-
+    send_battery_status_message();
 }
 
 void BMS::Task1000Ms()
 {
-
+    // Reserved for future use
 }
 
 // Read messages into modules and check alive
@@ -133,64 +133,43 @@ void BMS::read_message()
 }
 
 
-// void BMS::update_state_machine()
-// {
+void BMS::update_state_machine()
+{
+    BatteryPack::STATE_PACK pack_state = batteryPack.getState();
+    Contactormanager::State contactor_state = contactorManager.getState();
 
-        // for (int i = 0; i < numModules; i++)
-    // {
-    //     modules[i].check_alive();
-    // }
+    // Transition to fault state whenever a critical component reports a fault
+    if (pack_state == BatteryPack::FAULT || contactor_state == Contactormanager::FAULT)
+    {
+        dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_PACK_FAULT);
+        state = FAULT;
+        contactorManager.open();
+        return;
+    }
 
-    // switch (this->state)
-    // {
-    // case INIT: // Wait for all modules to go into init
-    // {
-    //     byte numModulesOperating = 0;
-    //     for (int i = 0; i < numModules; i++)
-    //     {
-    //         float v = modules[i].get_voltage();
-    //         if (modules[i].getState() == BatteryModule::OPERATING)
-    //         {
-    //             numModulesOperating++;
-    //         }
-    //         if (modules[i].getState() == BatteryModule::FAULT)
-    //         {
-    //             dtc |= DTC_PACK_MODULE_FAULT;
-    //         }
-    //     }
+    switch (state)
+    {
+    case INIT:
+        if (pack_state == BatteryPack::OPERATING && contactor_state == Contactormanager::CLOSED)
+        {
+            state = OPERATING;
+        }
+        break;
 
-    //     if (numModulesOperating == PACK_WAIT_FOR_NUM_MODULES)
-    //     {
-    //         state = OPERATING;
-    //     }
-    //     if (dtc > 0)
-    //     {
-    //         state = FAULT;
-    //     }
-    //     break;
-    // }
-    // case OPERATING: // Check if no module fault is popping up
-    // {
-    //     for (int i = 0; i < numModules; i++)
-    //     {
-    //         if (modules[i].getState() == BatteryModule::FAULT)
-    //         {
-    //             dtc |= DTC_PACK_MODULE_FAULT;
-    //         }
-    //     }
-    //     if (dtc > 0)
-    //     {
-    //         state = FAULT;
-    //     }
-    //     break;
-    // }
-    // case FAULT:
-    // {
-    //     // Additional fault handling logic can be added here if neededF 
-    //     break;
-    // }
-    // }
-// }
+    case OPERATING:
+        // If contactors open unexpectedly, fall back to INIT
+        if (contactor_state != Contactormanager::CLOSED)
+        {
+            state = INIT;
+        }
+        break;
+
+    case FAULT:
+        // Stay in fault until power cycle; ensure contactors are open
+        contactorManager.open();
+        break;
+    }
+}
 
 void BMS::send_message(CANMessage *frame)
 {

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -83,8 +83,8 @@ private:
     float measured_capacity_Ah; // Integrated capacity over a full cycle
 
     // --- Current Limits (Temperature) ---
-    float current_limit_peak_discharge;        // Peak allowed current (A) - discharge direction
-    float current_limit_rms_discharge;         // RMS allowed current (A)  - discharge direction
+    float current_limit_peak;        // Peak allowed discharge current (A)
+    float current_limit_rms;         // RMS allowed discharge current (A)
     float current_limit_peak_charge; // Peak charge current (A)
     float current_limit_rms_charge;  // Continuous charge current (A)
     float current_limit_rms_derated_discharge; // Derated RMS current limit for discharge
@@ -143,7 +143,7 @@ private:
     void rate_limit_current();
 
     //         // State maschine updating
-    //         void update_state_machine();
+    void update_state_machine();
 
     // Helper functions
     void send_message(CANMessage *frame); // Send out CAN message

--- a/src/comms_bms.cpp
+++ b/src/comms_bms.cpp
@@ -92,12 +92,12 @@ void BMS_Task2ms()
 
 void BMS_Task10ms()
 {
-    //battery_manager.Task10Ms();
+    battery_manager.Task10Ms();
 }
 
 void BMS_Task100ms()
 {
-    //battery_manager.Task100Ms();
+    battery_manager.Task100Ms();
 }
 
 Task BMS_task2ms_timer(2, TASK_FOREVER, &BMS_Task2ms);


### PR DESCRIPTION
## Summary
- implement `update_state_machine` in `battery_manager`
- call the state machine and status message tasks periodically
- align current limit variable names with docs
- refine state machine to include contactor status

## Testing
- `platformio run` *(fails: PlatformIO not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687573c5722c832bbb93e5772afa93db