### PR TITLE
Adjust BMS state machine behaviour

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -69,6 +69,10 @@
 
 #define BMS_MAX_DISCHARGE_PEAK_CURRENT 406 * 0.9 //Safetyfactor
 
+// Default current limit used in limp home mode when the BMS detects a fault
+#define BMS_LIMP_HOME_DISCHARGE_CURRENT 10.0f
+#define BMS_LIMP_HOME_CHARGE_CURRENT    10.0f
+
 // Internal resistance online estimation parameters
 #define IR_ESTIMATION_CURRENT_STEP_THRESHOLD 1.0f
 #define IR_ESTIMATION_ALPHA 0.1f


### PR DESCRIPTION
## Summary
- update BMS state logic to keep contactors closed on faults and use shunt state
- provide limp home current when in fault
- add limp home current definitions

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757b0db640832ba6e4735801b07f73