### PR TITLE
Add BMS status output to serial console

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -494,3 +494,19 @@ void BMS::send_message(CANMessage *frame)
         // Serial.println("Send nok");
     }
 }
+
+// Getter implementations
+BMS::STATE_BMS BMS::get_state() const { return state; }
+BMS::DTC_BMS BMS::get_dtc() const { return dtc; }
+BMS::VehicleState BMS::get_vehicle_state() const { return vehicle_state; }
+bool BMS::get_ready_to_shutdown() const { return ready_to_shutdown; }
+bool BMS::get_vcu_timeout() const { return vcu_timeout; }
+float BMS::get_max_charge_current() const { return max_charge_current; }
+float BMS::get_max_discharge_current() const { return max_discharge_current; }
+float BMS::get_soc() const { return soc; }
+float BMS::get_soc_ocv_lut() const { return soc_ocv_lut; }
+float BMS::get_soc_coulomb_counting() const { return soc_coulomb_counting; }
+float BMS::get_current_limit_peak_discharge() const { return current_limit_peak_discharge; }
+float BMS::get_current_limit_rms_discharge() const { return current_limit_rms_discharge; }
+float BMS::get_current_limit_peak_charge() const { return current_limit_peak_charge; }
+float BMS::get_current_limit_rms_charge() const { return current_limit_rms_charge; }

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -59,6 +59,22 @@ public:
     // Balancing control
     void update_balancing();
 
+    // Accessors for monitoring values
+    STATE_BMS get_state() const { return state; }
+    DTC_BMS get_dtc() const { return dtc; }
+    VehicleState get_vehicle_state() const { return vehicle_state; }
+    bool get_ready_to_shutdown() const { return ready_to_shutdown; }
+    bool get_vcu_timeout() const { return vcu_timeout; }
+    float get_max_charge_current() const { return max_charge_current; }
+    float get_max_discharge_current() const { return max_discharge_current; }
+    float get_soc() const { return soc; }
+    float get_soc_ocv_lut() const { return soc_ocv_lut; }
+    float get_soc_coulomb_counting() const { return soc_coulomb_counting; }
+    float get_current_limit_peak_discharge() const { return current_limit_peak_discharge; }
+    float get_current_limit_rms_discharge() const { return current_limit_rms_discharge; }
+    float get_current_limit_peak_charge() const { return current_limit_peak_charge; }
+    float get_current_limit_rms_charge() const { return current_limit_rms_charge; }
+
     bool is_balancing_finished() const { return balancing_finished; }
 
 private:

--- a/src/serial_console.cpp
+++ b/src/serial_console.cpp
@@ -10,6 +10,7 @@ void print_console_help() {
     console.println("  b - toggle balancing");
     console.println("  vX.XX - set balancing voltage");
     console.println("  mX - print module X status (0-7)");
+    console.println("  B - print BMS status");
     console.println("  h - print this help message");
 }
 
@@ -125,6 +126,32 @@ void print_module_status(int index) {
     console.printf("  Balancing: %d\n", mod.get_is_balancing());
 }
 
+void print_bms_status() {
+    console.printf("BMS State: %d, DTC: %d\n",
+                   battery_manager.get_state(), battery_manager.get_dtc());
+    console.printf(
+        "Vehicle State: %d, ReadyToShutdown: %d, VCU Timeout: %d\n",
+        battery_manager.get_vehicle_state(),
+        battery_manager.get_ready_to_shutdown(),
+        battery_manager.get_vcu_timeout());
+    console.printf("Max Charge Current: %.1fA, Max Discharge Current: %.1fA\n",
+                   battery_manager.get_max_charge_current(),
+                   battery_manager.get_max_discharge_current());
+    console.printf(
+        "SOC: %.1f%% (OCV %.1f%%, Coulomb %.1f%%)\n",
+        battery_manager.get_soc() * 100.0f,
+        battery_manager.get_soc_ocv_lut() * 100.0f,
+        battery_manager.get_soc_coulomb_counting() * 100.0f);
+    console.printf(
+        "Current Limits - Peak Discharge: %.1fA, RMS Discharge: %.1fA, Peak Charge: %.1fA, RMS Charge: %.1fA\n",
+        battery_manager.get_current_limit_peak_discharge(),
+        battery_manager.get_current_limit_rms_discharge(),
+        battery_manager.get_current_limit_peak_charge(),
+        battery_manager.get_current_limit_rms_charge());
+    console.printf("Balancing Finished: %d\n",
+                   battery_manager.is_balancing_finished());
+}
+
 void print_contactor_status() {
     console.printf("Contactor State: %s\n",
                    contactor_state_to_string(contactor_manager.getState()));
@@ -192,6 +219,9 @@ void serial_console() {
                 }
                 break;
             }
+            case 'B':
+                print_bms_status();
+                break;
             case 'h':
             case '?':
                 print_console_help();

--- a/src/serial_console.h
+++ b/src/serial_console.h
@@ -11,5 +11,6 @@ void print_console_help();
 void print_pack_status();
 void print_module_status(int index);
 void print_contactor_status();
+void print_bms_status();
 
 #endif // SERIAL_CONSOLE_H


### PR DESCRIPTION
## Summary
- allow printing of full BMS status over the serial console
- expose BMS values via accessor methods
- add console command `B` to show BMS values

## Testing
- `platformio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687585d402b8832baa4f7eed927690c2