### PR TITLE
Fix build issues

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -489,18 +489,3 @@ void BMS::send_message(CANMessage *frame)
     }
 }
 
-// Getter implementations
-BMS::STATE_BMS BMS::get_state() const { return state; }
-BMS::DTC_BMS BMS::get_dtc() const { return dtc; }
-BMS::VehicleState BMS::get_vehicle_state() const { return vehicle_state; }
-bool BMS::get_ready_to_shutdown() const { return ready_to_shutdown; }
-bool BMS::get_vcu_timeout() const { return vcu_timeout; }
-float BMS::get_max_charge_current() const { return max_charge_current; }
-float BMS::get_max_discharge_current() const { return max_discharge_current; }
-float BMS::get_soc() const { return soc; }
-float BMS::get_soc_ocv_lut() const { return soc_ocv_lut; }
-float BMS::get_soc_coulomb_counting() const { return soc_coulomb_counting; }
-float BMS::get_current_limit_peak_discharge() const { return current_limit_peak_discharge; }
-float BMS::get_current_limit_rms_discharge() const { return current_limit_rms_discharge; }
-float BMS::get_current_limit_peak_charge() const { return current_limit_peak_charge; }
-float BMS::get_current_limit_rms_charge() const { return current_limit_rms_charge; }

--- a/src/settings.h
+++ b/src/settings.h
@@ -98,6 +98,9 @@
 // Maximum absolute pack current (A) for valid OCV-based SOC estimation
 #define BMS_OCV_CURRENT_THRESHOLD 10.0f
 
+// Maximum allowable instantaneous pack discharge current (A)
+#define BMS_MAX_DISCHARGE_PEAK_CURRENT 409.0f
+
 // -----------------------------------------------------------------------------
 // Balancing Settings
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove duplicate BMS getter implementations
- define missing `BMS_MAX_DISCHARGE_PEAK_CURRENT`

## Testing
- `platformio run -e teensy41` *(fails: platformio missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876a4c220cc832b8e1f1a2b518f77cf