### PR TITLE
Remove debugging prints from Contactor

### DIFF
--- a/src/bms/contactor.cpp
+++ b/src/bms/contactor.cpp
@@ -23,20 +23,13 @@ void Contactor::initialise()
         if (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE)
         {
             _currentState = FAULT;
-            //Serial.println("State: Fault");
             digitalWrite(_outputPin, LOW);
-            //Serial.println("Fault: input signal high at init");
         }
         else
         {
             _currentState = OPEN;
-            //Serial.println("State: Open");
             _lastStateChange = millis();
         }
-    }
-    else
-    {
-        //Serial.println("Fault: Contactor was already initialized. A second initialize is not possible.");
     }
 }
 
@@ -45,7 +38,6 @@ void Contactor::close()
     if (_currentState == OPEN || _currentState == OPENING)
     {
         _currentState = CLOSING;
-        //Serial.println("State: Closing");
         _lastStateChange = millis();
         digitalWrite(_outputPin, HIGH);
     }
@@ -56,7 +48,6 @@ void Contactor::open()
     if (_currentState == CLOSED || _currentState == CLOSING)
     {
         _currentState = OPENING;
-        //Serial.println("State: Opening");
         _lastStateChange = millis();
         digitalWrite(_outputPin, LOW);
     }
@@ -75,8 +66,6 @@ bool Contactor::getInputPin()
 
 void Contactor::update()
 {
-    // PLOT("Contactor Input",digitalRead(_inputPin));
-    // PLOT("Contactor Output",digitalRead(_outputPin));
 
     switch (_currentState)
     {
@@ -86,7 +75,6 @@ void Contactor::update()
         if (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE)
         {
             _currentState = FAULT;
-            //Serial.println("State: Fault");
             digitalWrite(_outputPin, LOW);
         }
         break;
@@ -94,7 +82,6 @@ void Contactor::update()
         if (digitalRead(_inputPin) != CONTACTOR_CLOSED_STATE)
         {
             _currentState = FAULT;
-            ///Serial.println("State: Fault");
             digitalWrite(_outputPin, LOW);
         }
         break;
@@ -102,7 +89,6 @@ void Contactor::update()
         if ((millis() - _lastStateChange) > _timeout_ms)
         {
             _currentState = FAULT;
-            //Serial.println("State: Fault");
             digitalWrite(_outputPin, LOW);
         }
         else
@@ -112,7 +98,6 @@ void Contactor::update()
                 if (digitalRead(_inputPin) != CONTACTOR_CLOSED_STATE)
                 {
                     _currentState = OPEN;
-                    //Serial.println("State: Open");
                     _lastStateChange = millis();
                 }
             }
@@ -122,9 +107,6 @@ void Contactor::update()
         if ((millis() - _lastStateChange) > _timeout_ms)
         {
             _currentState = FAULT;
-            //Serial.println(millis());
-            //Serial.println(_lastStateChange);
-            //Serial.println("State: Fault");
             digitalWrite(_outputPin, LOW);
         }
         else
@@ -134,7 +116,6 @@ void Contactor::update()
                 if (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE)
                 {
                     _currentState = CLOSED;
-                    //Serial.println("State: Closed");
                     _lastStateChange = millis();
                 }
             }
@@ -145,5 +126,4 @@ void Contactor::update()
         break;
     }
 
-    // PLOT("Contactor State",_currentState);
 }


### PR DESCRIPTION
## Summary
- remove commented-out debug Serial and PLOT statements from the Contactor class

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6876a816ac14832b83545910978c0c52