### PR TITLE
Add shunt status and temperatures to console

### DIFF
--- a/src/serial_console.h
+++ b/src/serial_console.h
@@ -12,5 +12,6 @@ void print_pack_status();
 void print_module_status(int index);
 void print_contactor_status();
 void print_bms_status();
+void print_shunt_status();
 
 #endif // SERIAL_CONSOLE_H


### PR DESCRIPTION
## Summary
- extend console help and pack output
- print shunt/current sensor status via new command
- expose `print_shunt_status` in header
- include pack temperature info in status

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876aecf7574832b8f898692f7f738b9