### PR TITLE
Handle individual BMS component faults

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -124,7 +124,18 @@ void BMS::update_state_machine()
         contactor_state == Contactormanager::FAULT ||
         shunt_state == Shunt_ISA_iPace::FAULT)
     {
-        dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_PACK_FAULT);
+        if (pack_state == BatteryPack::FAULT)
+        {
+            dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_PACK_FAULT);
+        }
+        if (contactor_state == Contactormanager::FAULT)
+        {
+            dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_CONTACTOR_FAULT);
+        }
+        if (shunt_state == Shunt_ISA_iPace::FAULT)
+        {
+            dtc = static_cast<DTC_BMS>(dtc | DTC_BMS_SHUNT_FAULT);
+        }
         state = FAULT;
         max_discharge_current = BMS_LIMP_HOME_DISCHARGE_CURRENT;
         max_charge_current = BMS_LIMP_HOME_CHARGE_CURRENT;

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -29,6 +29,8 @@ public:
         DTC_BMS_CAN_SEND_ERROR = 1 << 0,
         DTC_BMS_CAN_INIT_ERROR = 1 << 1,
         DTC_BMS_PACK_FAULT = 1 << 2,
+        DTC_BMS_CONTACTOR_FAULT = 1 << 3,
+        DTC_BMS_SHUNT_FAULT = 1 << 4,
     } DTC_BMS;
 
     enum VehicleState

--- a/src/serial_console.cpp
+++ b/src/serial_console.cpp
@@ -52,6 +52,12 @@ static String bms_dtc_to_string(BMS::DTC_BMS dtc) {
         if (dtc & BMS::DTC_BMS_PACK_FAULT) {
             errorString += "PACK_FAULT, ";
         }
+        if (dtc & BMS::DTC_BMS_CONTACTOR_FAULT) {
+            errorString += "CONTACTOR_FAULT, ";
+        }
+        if (dtc & BMS::DTC_BMS_SHUNT_FAULT) {
+            errorString += "SHUNT_FAULT, ";
+        }
         errorString.remove(errorString.length() - 2);
     }
     return errorString;


### PR DESCRIPTION
## Summary
- extend BMS diagnostic codes to distinguish pack, contactor and shunt faults
- mark the correct DTC depending on which component reported a fault
- show new DTCs in the serial console

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688276447568832b9708af0c12669c67