### PR TITLE
Improve contactor status printing

### DIFF
--- a/src/bms/contactor.cpp
+++ b/src/bms/contactor.cpp
@@ -64,6 +64,11 @@ bool Contactor::getInputPin()
     return (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE);
 }
 
+bool Contactor::getOutputPin()
+{
+    return digitalRead(_outputPin);
+}
+
 void Contactor::update()
 {
 

--- a/src/bms/contactor.h
+++ b/src/bms/contactor.h
@@ -24,6 +24,7 @@ public:
     void open();
     State getState();
     bool getInputPin();
+    bool getOutputPin();
     void update();
 
 private:

--- a/src/bms/contactor_manager.cpp
+++ b/src/bms/contactor_manager.cpp
@@ -319,3 +319,23 @@ String Contactormanager::getDTCString()
 }
 
 Contactormanager::DTC_COM Contactormanager::getDTC() { return _dtc; }
+
+const Contactor &Contactormanager::getPositiveContactor() const
+{
+    return _positiveContactor;
+}
+
+const Contactor &Contactormanager::getPrechargeContactor() const
+{
+    return _prechargeContactor;
+}
+
+bool Contactormanager::isNegativeContactorClosed() const
+{
+    return _negativeContactor_closed;
+}
+
+bool Contactormanager::isContactorVoltageAvailable() const
+{
+    return _contactorVoltage_available;
+}

--- a/src/bms/contactor_manager.h
+++ b/src/bms/contactor_manager.h
@@ -43,6 +43,10 @@ public:
     State getState();
     DTC_COM getDTC();
     void update();
+    const Contactor &getPositiveContactor() const;
+    const Contactor &getPrechargeContactor() const;
+    bool isNegativeContactorClosed() const;
+    bool isContactorVoltageAvailable() const;
 
 private:
     const char *getCurrentStateString();

--- a/src/serial_console.cpp
+++ b/src/serial_console.cpp
@@ -141,6 +141,18 @@ static const char *contactor_state_to_string(Contactormanager::State state) {
     }
 }
 
+static const char *contactor_state_to_string(Contactor::State state) {
+    switch (state) {
+        case Contactor::INIT: return "INIT";
+        case Contactor::OPEN: return "OPEN";
+        case Contactor::CLOSING: return "CLOSING";
+        case Contactor::CLOSED: return "CLOSED";
+        case Contactor::OPENING: return "OPENING";
+        case Contactor::FAULT: return "FAULT";
+        default: return "UNKNOWN";
+    }
+}
+
 static String contactor_dtc_to_string(Contactormanager::DTC_COM dtc) {
     String errorString = "";
     if (dtc == Contactormanager::DTC_COM_NONE) {
@@ -257,13 +269,15 @@ void print_contactor_status() {
                    contactor_state_to_string(contactor_manager.getState()));
     console.printf("Contactor DTC: %s\n",
                    contactor_dtc_to_string(contactor_manager.getDTC()).c_str());
-    console.printf("POS_OUT:%d POS_IN:%d PRE_OUT:%d PRE_IN:%d NEG_IN:%d SUPPLY_IN:%d\n",
-                   digitalRead(CONTACTOR_POS_OUT_PIN),
-                   digitalRead(CONTACTOR_POS_IN_PIN),
-                   digitalRead(CONTACTOR_PRCHG_OUT_PIN),
-                   digitalRead(CONTACTOR_PRCHG_IN_PIN),
-                   digitalRead(CONTACTOR_NEG_IN_PIN),
-                  digitalRead(CONTACTOR_POWER_SUPPLY_IN_PIN));
+    const Contactor &pos = contactor_manager.getPositiveContactor();
+    const Contactor &pre = contactor_manager.getPrechargeContactor();
+    console.printf("POS:%s POS_IN:%d PRE:%s PRE_IN:%d NEG_IN:%d SUPPLY_IN:%d\n",
+                   contactor_state_to_string(pos.getState()),
+                   pos.getInputPin(),
+                   contactor_state_to_string(pre.getState()),
+                   pre.getInputPin(),
+                   contactor_manager.isNegativeContactorClosed(),
+                   contactor_manager.isContactorVoltageAvailable());
 }
 
 void print_shunt_status() {


### PR DESCRIPTION
## Summary
- expose contactor pin and status information through the `Contactormanager`
- add output pin getter to `Contactor`
- use these getters when printing contactor status
- print contactor state instead of output pin

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688276cdca50832b974ca22ddac408e3