### PR TITLE
Add external control mode for precharge contactor

### DIFF
--- a/src/bms/contactor.h
+++ b/src/bms/contactor.h
@@ -17,7 +17,8 @@ public:
         FAULT
     };
 
-    Contactor(int outputPin, int inputPin, int debounce_ms, int timeout_ms);
+    Contactor(int outputPin, int inputPin, int debounce_ms, int timeout_ms,
+              bool allowExternalControl = false);
 
     void initialise();
     void close();
@@ -34,6 +35,7 @@ private:
     unsigned int _timeout_ms;
     unsigned long _lastStateChange;
     State _currentState;
+    bool _allowExternalControl;
 };
 
 #endif

--- a/src/bms/contactor_manager.cpp
+++ b/src/bms/contactor_manager.cpp
@@ -5,8 +5,16 @@
 #include "bms/contactor.h"
 #include "utils/can_packer.h"
 
-Contactormanager::Contactormanager() : _prechargeContactor(CONTACTOR_PRCHG_OUT_PIN, CONTACTOR_PRCHG_IN_PIN, CONTACTOR_DEBOUNCE, CONTACTOR_TIMEOUT),
-                                       _positiveContactor(CONTACTOR_POS_OUT_PIN, CONTACTOR_POS_IN_PIN, CONTACTOR_DEBOUNCE, CONTACTOR_TIMEOUT)
+Contactormanager::Contactormanager() :
+    _prechargeContactor(CONTACTOR_PRCHG_OUT_PIN,
+                        CONTACTOR_PRCHG_IN_PIN,
+                        CONTACTOR_DEBOUNCE,
+                        CONTACTOR_TIMEOUT,
+                        true),
+    _positiveContactor(CONTACTOR_POS_OUT_PIN,
+                       CONTACTOR_POS_IN_PIN,
+                       CONTACTOR_DEBOUNCE,
+                       CONTACTOR_TIMEOUT)
 {
     _currentState = INIT;
 }


### PR DESCRIPTION
## Summary
- extend `Contactor` with an optional external control mode
- update state handling to accommodate external control
- enable the mode for the precharge contactor

## Testing
- `platformio` could not be run because it isn't installed in the environment

------
https://chatgpt.com/codex/tasks/task_e_68827cd66084832b804cd8e53f636081