### PR TITLE
Fix contactor API exposure

### DIFF
--- a/src/bms/contactor.cpp
+++ b/src/bms/contactor.cpp
@@ -55,18 +55,18 @@ void Contactor::open()
     }
 }
 
-Contactor::State Contactor::getState()
+Contactor::State Contactor::getState() const
 {
     return _currentState;
 }
 
-bool Contactor::getInputPin()
+bool Contactor::getInputPin() const
 {
 
     return (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE);
 }
 
-bool Contactor::getOutputPin()
+bool Contactor::getOutputPin() const
 {
     return digitalRead(_outputPin);
 }

--- a/src/bms/contactor.h
+++ b/src/bms/contactor.h
@@ -23,9 +23,9 @@ public:
     void initialise();
     void close();
     void open();
-    State getState();
-    bool getInputPin();
-    bool getOutputPin();
+    State getState() const;
+    bool getInputPin() const;
+    bool getOutputPin() const;
     void update();
 
 private:

--- a/src/bms/contactor_manager.cpp
+++ b/src/bms/contactor_manager.cpp
@@ -328,14 +328,24 @@ String Contactormanager::getDTCString()
 
 Contactormanager::DTC_COM Contactormanager::getDTC() { return _dtc; }
 
-const Contactor &Contactormanager::getPositiveContactor() const
+Contactor::State Contactormanager::getPositiveState() const
 {
-    return _positiveContactor;
+    return _positiveContactor.getState();
 }
 
-const Contactor &Contactormanager::getPrechargeContactor() const
+bool Contactormanager::getPositiveInputPin() const
 {
-    return _prechargeContactor;
+    return _positiveContactor.getInputPin();
+}
+
+Contactor::State Contactormanager::getPrechargeState() const
+{
+    return _prechargeContactor.getState();
+}
+
+bool Contactormanager::getPrechargeInputPin() const
+{
+    return _prechargeContactor.getInputPin();
 }
 
 bool Contactormanager::isNegativeContactorClosed() const

--- a/src/bms/contactor_manager.h
+++ b/src/bms/contactor_manager.h
@@ -43,8 +43,10 @@ public:
     State getState();
     DTC_COM getDTC();
     void update();
-    const Contactor &getPositiveContactor() const;
-    const Contactor &getPrechargeContactor() const;
+    Contactor::State getPositiveState() const;
+    bool getPositiveInputPin() const;
+    Contactor::State getPrechargeState() const;
+    bool getPrechargeInputPin() const;
     bool isNegativeContactorClosed() const;
     bool isContactorVoltageAvailable() const;
 
@@ -53,8 +55,8 @@ private:
     const char *getTargetStateString();
     String getDTCString();
 
-    Contactor _positiveContactor;
     Contactor _prechargeContactor;
+    Contactor _positiveContactor;
     unsigned long _lastPreChangeTime;
     State _currentState;
     State _targetState;

--- a/src/serial_console.cpp
+++ b/src/serial_console.cpp
@@ -362,13 +362,11 @@ void print_contactor_status() {
                    contactor_state_to_string(contactor_manager.getState()));
     console.printf("Contactor DTC: %s\n",
                    contactor_dtc_to_string(contactor_manager.getDTC()).c_str());
-    const Contactor &pos = contactor_manager.getPositiveContactor();
-    const Contactor &pre = contactor_manager.getPrechargeContactor();
     console.printf("POS:%s POS_IN:%d PRE:%s PRE_IN:%d NEG_IN:%d SUPPLY_IN:%d\n",
-                   contactor_state_to_string(pos.getState()),
-                   pos.getInputPin(),
-                   contactor_state_to_string(pre.getState()),
-                   pre.getInputPin(),
+                   contactor_state_to_string(contactor_manager.getPositiveState()),
+                   contactor_manager.getPositiveInputPin(),
+                   contactor_state_to_string(contactor_manager.getPrechargeState()),
+                   contactor_manager.getPrechargeInputPin(),
                    contactor_manager.isNegativeContactorClosed(),
                    contactor_manager.isContactorVoltageAvailable());
 }


### PR DESCRIPTION
## Summary
- reorder contactor member variables to silence -Wreorder
- mark Contactor getters as const
- hide Contactor instances behind Contactormanager getters
- update serial console to use new getters

## Testing
- `pio run` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882811bd854832ba3d7ea59a4b22fd3