### PR TITLE
Handle external control in initialization

### DIFF
--- a/src/bms/contactor.cpp
+++ b/src/bms/contactor.cpp
@@ -24,8 +24,16 @@ void Contactor::initialise()
         digitalWrite(_outputPin, LOW);
         if (digitalRead(_inputPin) == CONTACTOR_CLOSED_STATE)
         {
-            _currentState = FAULT;
-            digitalWrite(_outputPin, LOW);
+            if (_allowExternalControl)
+            {
+                _currentState = CLOSED;
+                _lastStateChange = millis();
+            }
+            else
+            {
+                _currentState = FAULT;
+                digitalWrite(_outputPin, LOW);
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary
- update contactor initialization logic to respect external control flag

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882823b0f30832b984c32c46c7af406