### PR TITLE
Fix HMI message CRC location

### DIFF
--- a/documentation/CAN_Message_Packing.md
+++ b/documentation/CAN_Message_Packing.md
@@ -54,8 +54,8 @@ The following tables describe the structure of all CAN messages exchanged betwee
 | 0-1 | Averaged Energy per Hour | `uint16` | kWh × 100 | 0–65535 | 0–655.35 kWh |
 | 2-3 | Time to Full (Charging) | `uint16` | minutes | 0–65535 |  |
 | 4 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
-| 5 | CRC8 | `uint8` |  |  |  |
-| 6-7 | reserved |  |  |  |  |
+| 5-6 | reserved |  |  |  |  |
+| 7 | CRC8 | `uint8` |  |  |  |
 
 ## VCU to BMS
 

--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -519,7 +519,7 @@ void BMS::send_battery_status_message()
     msg.data[5] = 0;
     msg.data[6] = 0;
     msg.data[7] = 0;
-    msg.data[5] = can_crc8(msg.data);
+    msg.data[7] = can_crc8(msg.data);
     send_message(&msg);
 
     msg5_counter = (msg5_counter + 1) & 0x0F;


### PR DESCRIPTION
## Summary
- place CRC for BMS_HMI on byte 7
- update CAN message documentation

## Testing
- `pip install platformio` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6883e4721a7c832bb3307fcdf4877e9f