### PR TITLE
Fix CRC position for VCU command

### DIFF
--- a/documentation/CAN_Message_Packing.md
+++ b/documentation/CAN_Message_Packing.md
@@ -67,5 +67,5 @@ All signals below are unsigned unless otherwise noted.
 | 1 | RequestBMSShutdown | `uint8` | 0/1 | boolean as `uint8` |
 | 2 | RequestContactorClose | `uint8` | 0/1 | boolean as `uint8` |
 | 3 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | bits 7–4 always 0 |
-| 4 | CRC8 | `uint8` |  |  |
-| 5-7 | reserved |  |  |  |
+| 4-6 | reserved |  |  |  |  |
+| 7 | CRC8 | `uint8` |  |  |

--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -411,9 +411,9 @@ void BMS::read_message()
         {
             uint8_t tmp[8];
             memcpy(tmp, msg.data, 8);
-            tmp[4] = 0; // crc byte cleared
+            tmp[7] = 0; // crc byte cleared
             uint8_t crc = can_crc8(tmp);
-            // if (crc == msg.data[4])
+            // if (crc == msg.data[7])
             // {
                 vehicle_state = static_cast<VehicleState>(msg.data[0]);
                 ready_to_shutdown = msg.data[1];
@@ -451,7 +451,7 @@ void BMS::send_battery_status_message()
     msg.data[5] = (uint8_t)(batteryPack.get_highest_cell_voltage() * 50.0f);
     msg.data[6] = msg1_counter & 0x0F;
     msg.data[7] = 0;
-    msg.data[7] = can_crc8(msg.data);
+    msg.data[5] = can_crc8(msg.data);
     send_message(&msg);
     msg1_counter = (msg1_counter + 1) & 0x0F;
 


### PR DESCRIPTION
## Summary
- revert CRC field for `BMS_HMI`
- expect CRC for the VCU command on byte 7
- update documentation for CRC locations

## Testing
- `pip install platformio` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6883e4721a7c832bb3307fcdf4877e9f