### PR TITLE
Update pack power doc and CRC location

### DIFF
--- a/documentation/CAN_Message_Packing.md
+++ b/documentation/CAN_Message_Packing.md
@@ -21,7 +21,7 @@ The following tables describe the structure of all CAN messages exchanged betwee
 | 1 | Max Cell Temp | `uint8` | (°C) + 40 | 0–167 | –40 °C to +127 °C |
 | 2 | Cell Voltage Avg | `uint8` | V × 50 | 0–255 | 0–5.10 V |
 | 3 | Cell Voltage Delta | `uint8` | V × 100 | 0–255 | 0–2.55 V |
-| 4-5 | Pack Power | `uint16` | (kW × 10) + 2000 | 0–65535 | –200 kW to +4553 kW |
+| 4-5 | Pack Power | `uint16` | (kW × 100) + 30000 | 0–50000 | –300 kW to +200 kW |
 | 6 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
 | 7 | CRC8 | `uint8` |  |  |  |
 
@@ -54,8 +54,8 @@ The following tables describe the structure of all CAN messages exchanged betwee
 | 0-1 | Averaged Energy per Hour | `uint16` | kWh × 100 | 0–65535 | 0–655.35 kWh |
 | 2-3 | Time to Full (Charging) | `uint16` | minutes | 0–65535 |  |
 | 4 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
-| 5 | CRC8 | `uint8` |  |  |  |
-| 6-7 | reserved |  |  |  |  |
+| 5-6 | reserved |  |  |  |  |
+| 7 | CRC8 | `uint8` |  |  |  |
 
 ## VCU to BMS
 

--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -458,7 +458,7 @@ void BMS::send_battery_status_message()
     uint8_t maxT = (uint8_t)(batteryPack.get_highest_temperature() + 40.0f);
     uint8_t cellAvg = (uint8_t)(batteryPack.get_pack_voltage() / (MODULES_PER_PACK * CELLS_PER_MODULE) * 50.0f);
     uint8_t cellDelta = (uint8_t)(batteryPack.get_delta_cell_voltage() * 100.0f);
-    uint16_t packPower = (uint16_t)((batteryPack.get_pack_voltage() * shunt.getCurrent() / 1000.0f) * 10.0f + 2000.0f);
+    uint16_t packPower = (uint16_t)((batteryPack.get_pack_voltage() * shunt.getCurrent() / 1000.0f) * 100.0f + 30000.0f);
     msg.data[0] = minT;
     msg.data[1] = maxT;
     msg.data[2] = cellAvg;


### PR DESCRIPTION
## Summary
- document pack power with 0.01 kW resolution
- fix CRC field position for the BMS_HMI message

## Testing
- `make -n` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6885082bb1c0832ba140e7c756220482