### PR TITLE
Gate OCV-based SOC updates on rest timer

### DIFF
--- a/src/bms/battery_manager.cpp
+++ b/src/bms/battery_manager.cpp
@@ -10,7 +10,7 @@
 #include "utils/soc_lookup.h"
 #include "utils/resistance_lookup.h"
 #include "serial_console.h"
-#include <math.h>
+#include <cmath>
 
 // #define DEBUG
 
@@ -38,7 +38,7 @@ BMS::BMS(BatteryPack &_batteryPack, Shunt_ISA_iPace &_shunt, Contactormanager &_
     last_vcu_msg = 0;
     vcu_timeout = false;
     balancing_finished = false;
-    ocv_current_settle_start_ms = 0;
+    ocv_current_settle_start_ms = 0U;
 }
 
 void BMS::initialize()
@@ -172,36 +172,38 @@ void BMS::update_state_machine()
 
 void BMS::update_soc_ocv_lut()
 {
-    const float current = shunt.getCurrent();
-    pack_current = current;
+    pack_current = shunt.getCurrent();
 
-    const float abs_current = fabs(current);
+    const float abs_current = std::fabs(pack_current);
+    const bool below_threshold = abs_current <= BMS_OCV_CURRENT_THRESHOLD;
 
-    if (abs_current <= BMS_OCV_CURRENT_THRESHOLD)
-    {
-        const unsigned long now = millis();
-
-        if (ocv_current_settle_start_ms == 0)
-        {
-            ocv_current_settle_start_ms = now;
-        }
-
-        if (ocv_current_settle_start_ms != 0 &&
-            (now - ocv_current_settle_start_ms) >= BMS_OCV_CURRENT_SETTLE_TIME_MS)
-        {
-            // Use lowest cell voltage across the pack as OCV reference
-            const float ocv = batteryPack.get_lowest_cell_voltage();
-
-            // Average pack temperature handled by BatteryPack
-            const float avgTemp = batteryPack.get_average_temperature();
-
-            soc_ocv_lut = SOC_FROM_OCV_TEMP(avgTemp, ocv);
-        }
-    }
-    else
+    if (!below_threshold)
     {
         ocv_current_settle_start_ms = 0;
+        return;
     }
+
+    const uint32_t now = millis();
+
+    if (ocv_current_settle_start_ms == 0U)
+    {
+        ocv_current_settle_start_ms = now;
+        return;
+    }
+
+    const uint32_t elapsed = now - ocv_current_settle_start_ms;
+    if (elapsed < BMS_OCV_CURRENT_SETTLE_TIME_MS)
+    {
+        return;
+    }
+
+    // Use lowest cell voltage across the pack as OCV reference
+    const float ocv = batteryPack.get_lowest_cell_voltage();
+
+    // Average pack temperature handled by BatteryPack
+    const float avgTemp = batteryPack.get_average_temperature();
+
+    soc_ocv_lut = SOC_FROM_OCV_TEMP(avgTemp, ocv);
 }
 
 void BMS::update_soc_coulomb_counting()
@@ -284,7 +286,7 @@ void BMS::estimate_internal_resistance_online()
 
     float deltaI = pack_current - last_pack_current;
 
-    if (fabs(deltaI) > current_threshold)
+    if (std::fabs(deltaI) > current_threshold)
     {
         for (int i = 0; i < CELLS_PER_MODULE * MODULES_PER_PACK; ++i)
         {

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -98,6 +98,9 @@ private:
     float dt;
     bool invalid_data;
 
+    // Timestamp tracking when pack current last entered the OCV-valid region
+    unsigned long ocv_current_settle_start_ms;
+
     float power; // in Ws
 
     // SOC

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -99,7 +99,7 @@ private:
     bool invalid_data;
 
     // Timestamp tracking when pack current last entered the OCV-valid region
-    unsigned long ocv_current_settle_start_ms;
+    uint32_t ocv_current_settle_start_ms;
 
     float power; // in Ws
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -102,6 +102,9 @@
 
 // Maximum absolute pack current (A) for valid OCV-based SOC estimation
 #define BMS_OCV_CURRENT_THRESHOLD 10.0f
+// Minimum time (ms) that pack current must stay below the OCV threshold
+// before an OCV-based SOC update is considered valid
+#define BMS_OCV_CURRENT_SETTLE_TIME_MS 5000UL
 
 // Maximum allowable instantaneous pack discharge current (A)
 #define BMS_MAX_DISCHARGE_PEAK_CURRENT 409.0f


### PR DESCRIPTION
## Summary
- add a configurable settle time parameter for OCV-based SOC estimation
- track when pack current has remained under the OCV threshold long enough
- only refresh the SOC OCV LUT after the pack current is stable for the required duration

## Testing
- Not run (platformio command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cab896a114832ba547712d6569045d