### PR TITLE
Initialize energy metrics defaults and adjust HMI layout

### DIFF
--- a/documentation/CAN_Message_Packing.md
+++ b/documentation/CAN_Message_Packing.md
@@ -51,10 +51,10 @@ The following tables describe the structure of all CAN messages exchanged betwee
 
 | Byte | Signal | Type | Scaling/Offset | Range | Notes |
 |-----|--------|------|---------------|-------|-------|
-| 0-1 | Averaged Energy per Hour | `uint16` | kWh × 100 | 0–65535 | 0–655.35 kWh |
-| 2-3 | Time to Full (Charging) | `uint16` | minutes | 0–65535 |  |
-| 4 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
-| 5-6 | reserved |  |  |  |  |
+| 0-1 | Averaged Energy per Hour | `int16` | kWh × 100 | –32768–32767 | sign indicates charge (–) or discharge (+) |
+| 2-3 | Remaining Time | `uint16` | seconds | 0–65535 | time to empty when discharging, time to full when charging |
+| 4-5 | Remaining Energy | `uint16` | Wh | 0–65535 | energy left |
+| 6 | Counter (4&nbsp;bit) | `uint8` | lower 4 bits only | 0–15 | bits 7–4 always 0 |
 | 7 | CRC8 | `uint8` |  |  |  |
 
 ## VCU to BMS

--- a/src/bms/battery_manager.h
+++ b/src/bms/battery_manager.h
@@ -53,6 +53,8 @@ public:
     void initialize();
     void read_message(); // Poll messages
 
+    void set_pack_power(float pack_power_w);
+
     void Task2Ms();  // Read Can messages ?
     void Task10Ms(); // Poll messages
     void Task100Ms();
@@ -98,7 +100,8 @@ private:
     float dt;
     bool invalid_data;
 
-    float power; // in Ws
+    float power; // Optional pack power reading in W
+    bool pack_power_valid;
 
     // SOC
     float soc_ocv_lut;       // SOC from OCV-Temp LUT
@@ -143,9 +146,14 @@ private:
     bool balancing_finished;
 
     // Non-Volatile Variable!!
-    float watt_seconds;
-    float ampere_seconds;
-    float total_capacity = BMS_TOTAL_CAPACITY;
+    float measured_capacity_Wh = 28000.0f;
+    float avg_energy_per_hour; // kWh per hour
+    float remaining_wh;        // Remaining energy in Wh
+    float time_remaining_s;    // Remaining time until empty/full depending on sign
+    float avg_power_w;         // Internal average power for filtering
+    float last_instantaneous_power_w; // Latest instantaneous power sample (W)
+
+    void update_energy_metrics();
 
     void send_battery_status_message();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -68,7 +68,9 @@
 #define BMS_MSG_HMI 0x41E
 #define BMS_VCU_TIMEOUT 300
 
-#define BMS_TOTAL_CAPACITY 345 * 3600 * CELLS_PER_MODULE; //Num modules missing 345Wh 3600 s/H 12 Cells. Unit: Ws
+#define ENERGY_AVG_WINDOW_SEC 5.0f
+#define ENERGY_MIN_VALID_POWER_W 1.0f
+#define BMS_INITIAL_REMAINING_WH (345.0f * 7.0f * 12.0f)
 
 //BMW i3 Specs from Samsung SDI document
 #define SAFETY_LIMIT_CHARGE 4.25


### PR DESCRIPTION
## Summary
- seed the remaining energy estimate with the configured nominal pack capacity and reuse the last power sample when external telemetry is absent
- expose configuration constants for the minimum meaningful power reading and use the SoC proxy to derive runtime without clamping
- move the HMI counter to byte 6 and document the updated payload layout

## Testing
- not run (ACAN_T4.h dependency unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68854b6630e8832b82937b078eed8d8f