### PR TITLE
Add compile-time firmware version command

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,8 @@
 platform = teensy
 board = teensy41
 framework = arduino
-build_flags = 
-	-D USB_DUAL_SERIAL
+build_flags =
+        -D USB_DUAL_SERIAL
 monitor_port = COM4
 lib_deps = 
 	pierremolinaro/ACAN_T4@^1.1.5

--- a/src/firmware_version.h
+++ b/src/firmware_version.h
@@ -1,0 +1,3 @@
+#pragma once
+
+constexpr char FIRMWARE_BUILD_INFO[] = __DATE__ " " __TIME__;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "bms/battery_manager.h"
 #include "comms_bms.h"
 #include "serial_console.h"
+#include "firmware_version.h"
 
 #ifndef __IMXRT1062__
 #error "This sketch should be compiled for Teensy 4.1"
@@ -55,6 +56,8 @@ void setup()
 #endif
 
   Serial.println("Setup software modules:");
+  Serial.print("Firmware version: ");
+  Serial.println(FIRMWARE_BUILD_INFO);
 
   // Setup SW components
   //-- only constructors go here. No setup if initialization methods

--- a/src/serial_console.cpp
+++ b/src/serial_console.cpp
@@ -1,4 +1,5 @@
 #include "serial_console.h"
+#include "firmware_version.h"
 #include <ctype.h>
 
 static const char *pack_state_to_string(BatteryPack::STATE_PACK state) {
@@ -126,6 +127,7 @@ void print_console_help() {
     console.println("  mX - print module X status (0-7)");
     console.println("  B - print BMS status");
     console.println("  i - print current sensor status");
+    console.println("  F - print firmware version");
     console.println("  h - print this help message");
 }
 
@@ -422,6 +424,10 @@ void serial_console() {
                 break;
             case 'B':
                 print_bms_status();
+                break;
+            case 'F':
+                console.print("Firmware version: ");
+                console.println(FIRMWARE_BUILD_INFO);
                 break;
             case 'h':
             case '?':


### PR DESCRIPTION
## Summary
- rely on the compiler-provided build date/time for firmware version information and remove the git commit hash script
- include the build information in setup logging and expose it via a new `F` serial console command

## Testing
- not run (embedded firmware change)

------
https://chatgpt.com/codex/tasks/task_e_68dd74a4170c832b817c240739ca6b70