### PR TITLE
Ensure firmware build timestamp updates each build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,8 @@
 platform = teensy
 board = teensy41
 framework = arduino
+extra_scripts =
+        pre:scripts/generate_build_info.py
 build_flags =
         -D USB_DUAL_SERIAL
 monitor_port = COM4

--- a/scripts/generate_build_info.py
+++ b/scripts/generate_build_info.py
@@ -1,0 +1,10 @@
+from datetime import datetime, timezone
+
+from SCons.Script import Import
+
+Import("env")
+
+now = datetime.now(timezone.utc)
+timestamp = now.strftime("%Y-%m-%d %H:%M:%S %Z") or now.isoformat()
+
+env.Append(BUILD_FLAGS=[f'-DBUILD_TIMESTAMP="{timestamp}"'])

--- a/src/firmware_version.h
+++ b/src/firmware_version.h
@@ -1,3 +1,7 @@
 #pragma once
 
-constexpr char FIRMWARE_BUILD_INFO[] = __DATE__ " " __TIME__;
+#ifndef BUILD_TIMESTAMP
+#define BUILD_TIMESTAMP __DATE__ " " __TIME__
+#endif
+
+constexpr char FIRMWARE_BUILD_INFO[] = BUILD_TIMESTAMP;


### PR DESCRIPTION
## Summary
- add a pre-build script that injects the current UTC timestamp into the build flags
- update the firmware version header to use the injected timestamp with a macro fallback
- wire the pre-build script into the Teensy 4.1 PlatformIO environment configuration

## Testing
- not run (PlatformIO CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2539d22d8832bb7d3a28478511692