### PR TITLE
Fix contactor feedback configuration

### DIFF
--- a/src/bms/contactor.cpp
+++ b/src/bms/contactor.cpp
@@ -2,8 +2,6 @@
 #include "contactor.h"
 #include "settings.h"
 
-#define CONTACTOR_DISABLE_FEEDBACK
-
 Contactor::Contactor(int outputPin, int inputPin, int debounce_ms, int timeout_ms,
                      bool allowExternalControl)
     : _outputPin(outputPin),


### PR DESCRIPTION
## Summary
- remove the hard-coded CONTACTOR_DISABLE_FEEDBACK definition from the contactor driver
- allow the build-time setting in settings.h to control whether feedback is ignored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e253abede8832bbc7d1c19f2281d75