### PR TITLE
Fix firmware build info definition and CAN ID comparison

### DIFF
--- a/src/bms/battery i3/module.cpp
+++ b/src/bms/battery i3/module.cpp
@@ -46,7 +46,7 @@ BatteryModule::BatteryModule(int _id, BatteryPack *_pack)
 
 void BatteryModule::process_message(CANMessage &msg)
 {
-    if ((msg.id & 0x00F) != id) // check if module id belongs to this module
+    if ((msg.id & 0x00F) != static_cast<uint32_t>(id)) // check if module id belongs to this module
     {
         return;
     }

--- a/src/firmware_version.h
+++ b/src/firmware_version.h
@@ -4,4 +4,4 @@
 #define BUILD_TIMESTAMP __DATE__ " " __TIME__
 #endif
 
-constexpr char FIRMWARE_BUILD_INFO[] = BUILD_TIMESTAMP;
+constexpr const char *FIRMWARE_BUILD_INFO = BUILD_TIMESTAMP;


### PR DESCRIPTION
## Summary
- align the CAN message module ID comparison with the unsigned CAN identifier
- declare the firmware build info constant as a pointer to support externally-defined build timestamps

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e258b99898832baeb1381b064143f7